### PR TITLE
Add new GitHub profile widgets from GitClear

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,25 @@ Happy code!
 ```
 <a href='https://www.gitclear.com/snap_changelogs/229cc023-f4a6-4d27-a111-31e19a79c7d9' target='_blank'><img src="https://www.gitclear.com/snap_changelogs/229cc023-f4a6-4d27-a111-31e19a79c7d9.png" alt="Facebook React velocity past 12 months" /></a>
 
-Show repo velocity over a configurable time range. [More details](https://www.gitclear.com/github_profile_dynamic_readme_free) or [video setup for GitHub Sponsors](https://www.youtube.com/watch?v=r6ELGM4PcuA)
+Show repo velocity over a configurable time range. [Sign up for perma-free GitHub Profile widget & choose repos to show](https://www.gitclear.com/github_profile_dynamic_readme_free) or [3 min video walkthrough for GitHub Sponsor devs](https://www.youtube.com/watch?v=r6ELGM4PcuA).
+
+If you have a repo with 1,000 stars, contact hello@gitclear.com for personalized setup help. 
 
 ---
 
+### GitClear Visual Changelog Widget
+```
+<img src='https://www.gitclear.com/snap_changelogs/b02dd34c-b375-42b5-a1c0-bbfaac42917b.png' />
+```
+<a href='https://www.gitclear.com/snap_changelogs/b02dd34c-b375-42b5-a1c0-bbfaac42917b' target='_blank'><img src='https://www.gitclear.com/snap_changelogs/b02dd34c-b375-42b5-a1c0-bbfaac42917b.png' /></a>
+
+Show a visual changelog for a committer, or repo(s). Uses AI to interpret uploaded screenshots with recent work ✨  
+
+[Signup for a free GitHub Profile widget (+ pick repos)](https://www.gitclear.com/github_profile_dynamic_readme_free)
+
+[Optional in-depth explainer on how screenshots are mapped to work](https://www.gitclear.com/blog/how_we_built_an_automatic_changelog_generator_for_github_open_source) or [video showing how visual changelogs work](https://www.youtube.com/watch?v=xKs0vknhJis),
+
+---
 ### GitHub All Stats
 <img src="https://myreadme.vercel.app/api/embed/pressjump?panels=userstatistics,toprepositories,toplanguages,commitgraph" alt="reimaginedreadme" />
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ Happy code!
 
 ---
 
+### GitClear Free GitHub Profile Velocity Widget
+```
+<img src='https://www.gitclear.com/snap_changelogs/229cc023-f4a6-4d27-a111-31e19a79c7d9.png' />
+```
+<a href='https://www.gitclear.com/snap_changelogs/229cc023-f4a6-4d27-a111-31e19a79c7d9' target='_blank'><img src="https://www.gitclear.com/snap_changelogs/229cc023-f4a6-4d27-a111-31e19a79c7d9.png" alt="Facebook React velocity past 12 months" /></a>
+
+Show repo velocity over a configurable time range. [More details](https://www.gitclear.com/github_profile_dynamic_readme_free) or [video setup for GitHub Sponsors](https://www.youtube.com/watch?v=r6ELGM4PcuA)
+
+---
+
 ### GitHub All Stats
 <img src="https://myreadme.vercel.app/api/embed/pressjump?panels=userstatistics,toprepositories,toplanguages,commitgraph" alt="reimaginedreadme" />
 


### PR DESCRIPTION
Wow, what a cool idea to create this repo! Seems like Google has so little info about what GitHub Profile widgets are available, so this repo is pulling a lot of weight to spread useful details.

For this PR, I linked two of the [~20 different types of widgets GitClear has launched in the past few months](https://www.gitclear.com/help/share_progress_status_update_via_snap_changelog_overview). If you would like to see a couple more flavors of widgets GitClear can generate, let me know and I can add them? For starters I'm trying not to use up too much vertical space.

If users sign up through the `https://www.gitclear.com/github_profile_dynamic_readme_free` link, we will default them to a perma-free GitClear subscription, and process up to three repos worth of data they select during login. Since our company is just a small group of Seattle developers without VC backing, we can get away with giving away free stuff like this without having to explain it to "the business people" who would ask hard questions about the ROI. 😅 

@madushadhanushka - if you want to set up one of these widgets in your own profile (I see you have a couple widgets in it currently), feel free to email me bill at gitclear and I can help you formulate the coolest-looking versions of these to show what you've worked on lately (average email response time 2-3 biz days). 

Thanks for considering my PR, and for keeping this repo in general!